### PR TITLE
Fix dynarec on Win32 with DEP enabled.

### DIFF
--- a/PCem/codegen_x86.c
+++ b/PCem/codegen_x86.c
@@ -20,6 +20,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #endif
+#ifdef WIN32
+#include <windows.h>
+#endif
 
 int codegen_flags_changed = 0;
 int codegen_fpu_entered = 0;
@@ -64,7 +67,11 @@ void codegen_init()
 	long pagemask = ~(pagesize - 1);
 #endif
         
+#if WIN32
+        codeblock = VirtualAlloc(NULL, BLOCK_SIZE * sizeof(codeblock_t), MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+#else
         codeblock = malloc(BLOCK_SIZE * sizeof(codeblock_t));
+#endif
         codeblock_hash = malloc(HASH_SIZE * sizeof(codeblock_t *));
 
         memset(codeblock, 0, BLOCK_SIZE * sizeof(codeblock_t));


### PR DESCRIPTION
Memory was allocated the right way on x64, but not x86.

This pull request should fix that; please note I haven't tested it at all.
